### PR TITLE
Project upgrade. Ability to skip route generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ project/target
 .settings
 bin
 .idea/
+.bsp

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,12 +9,16 @@ pipeline {
 
   agent {
     kubernetes {
-      label 'worker-aylien-query-dsl'
+      label 'worker-sbt-swagger-models'
       inheritFrom 'default'
-
       containerTemplates([
-        containerTemplate(name: 'sbt', image: 'gcr.io/aylien-production/sbt', command: 'cat', ttyEnabled: true),
-        containerTemplate(name: 'helm', image: 'gcr.io/aylien-production/helm', command: 'cat', ttyEnabled: true)
+        containerTemplate(
+            name: 'sbt',
+            image: 'gcr.io/aylien-production/sbt-jdk11',
+            alwaysPullImage: true,
+            privileged: true,
+            ttyEnabled: true
+        )
       ])
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,17 @@
 name := "sbt-swagger-models"
 organization := "io.grhodes.sbt"
 
-version := "1.3.0"
+version := "1.4.0"
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.12.17"
 
 enablePlugins(SbtPlugin)
 
 libraryDependencies ++= Seq(
-  "io.swagger.codegen.v3" % "swagger-codegen" % "3.0.8",
-  "io.grhodes" %% "simple-scala-generator" % "1.3.0",
-  "org.scalactic" %% "scalactic" % "3.0.1" % Test,
-  "org.scalatest" %% "scalatest" % "3.0.1" % Test
+  "io.swagger.codegen.v3" % "swagger-codegen" % "3.0.44",
+  "io.grhodes" %% "simple-scala-generator" % "1.4.0",
+  "org.scalactic" %% "scalactic" % "3.2.16" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.16" % Test
 )
 
 scalacOptions ++= List("-unchecked")
@@ -21,7 +21,7 @@ githubOwner := "AYLIEN"
 githubRepository := "sbt-swagger-models"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
-initialCommands in console := """import io.grhodes.sbt.swagger.models._"""
+console / initialCommands := """import io.grhodes.sbt.swagger.models._"""
 
 // set up 'scripted; sbt plugin for testing sbt plugins
 scriptedBufferLog := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.8.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.2")
+addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")

--- a/src/main/scala/io/grhodes/sbt/swagger/models/ModelGenerator.scala
+++ b/src/main/scala/io/grhodes/sbt/swagger/models/ModelGenerator.scala
@@ -1,32 +1,38 @@
 package io.grhodes.sbt.swagger.models
 
-import java.util.ServiceLoader
-
-import io.swagger.codegen.v3.{ClientOptInput, CodegenConfig, DefaultGenerator}
+import io.grhodes.simple.codegen.{ BaseScalaCodegen, SimplePlayCodegen }
 import io.swagger.codegen.v3.config.CodegenConfigurator
+import io.swagger.codegen.v3.{ CodegenConfig, DefaultGenerator }
 import org.apache.commons.io.FilenameUtils
-import sbt._
+import sbt.*
 import sbt.Keys.TaskStreams
 
+import java.nio.file.{ FileSystems, Files, Path, Paths, StandardOpenOption }
+import java.util
+import java.util.{ Collections, ServiceLoader }
 import scala.annotation.tailrec
+import scala.io.Source
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
 
 object ModelGenerator {
 
   val fileFilter: FileFilter = "*.yml" || "*.yaml" || "*.json"
 
-  def apply(streams: TaskStreams,
-            srcManagedDir: File,
-            srcDir: File,
-            baseDir: File,
-            specFile: Option[String],
-            basePkg: Option[String],
-            modelPkg: Option[String],
-            apiPkg: Option[String],
-            disableTypesafeIds: Boolean,
-            enumVendorExtensionName: Option[String],
-            taggedAttributes: Seq[String],
-            generator: String,
-            verbose: Boolean): scala.Seq[java.io.File] = {
+  def apply(
+    streams: TaskStreams,
+    srcManagedDir: File,
+    srcDir: File,
+    baseDir: File,
+    targetDir: File,
+    specFile: Option[String],
+    basePkg: Option[String],
+    modelPkg: Option[String],
+    apiPkg: Option[String],
+    generator: String,
+    verbose: Boolean,
+    skipRouteGeneration: Boolean
+  ): scala.Seq[java.io.File] = {
 
     streams.log.info(s"Source: $srcDir")
 
@@ -39,7 +45,21 @@ object ModelGenerator {
       file(cache.getAbsolutePath) / "swagger",
       inStyle = FilesInfo.lastModified,
       outStyle = FilesInfo.exists
-    )(compile(streams.log, srcManagedDir, baseDir, serviceSpec, basePkg, modelPkg, apiPkg, generator, verbose))
+    )(
+      compile(
+        log = streams.log,
+        srcManagedDir = srcManagedDir,
+        baseDir = baseDir,
+        targetDir = targetDir,
+        specFile = serviceSpec,
+        basePkg = basePkg,
+        modelPkg = modelPkg,
+        apiPkg = apiPkg,
+        generator = generator,
+        verbose = verbose,
+        skipRouteGeneration = skipRouteGeneration
+      )
+    )
 
     cachedCompile((srcDir ** fileFilter).get.toSet).toSeq
   }
@@ -62,44 +82,66 @@ object ModelGenerator {
     def loop(): Option[CodegenConfig] = {
       if (it.hasNext) {
         val config = it.next()
-        if (config.getName == name) Some(config)
-        else loop()
-      } else None
+        if (config.getName == name) Some(config) else loop()
+      } else {
+        None
+      }
     }
 
     loop()
   }
 
-  private def compile(log: Logger,
-                      srcManagedDir: File,
-                      baseDir: File,
-                      specFile: Option[File],
-                      basePkg: Option[String],
-                      modelPkg: Option[String],
-                      apiPkg: Option[String],
-                      generator: String,
-                      verbose: Boolean)(in: Set[File]) = {
+  private def compile(
+    log: Logger,
+    srcManagedDir: File,
+    baseDir: File,
+    targetDir: File,
+    specFile: Option[File],
+    basePkg: Option[String],
+    modelPkg: Option[String],
+    apiPkg: Option[String],
+    generator: String,
+    verbose: Boolean,
+    skipRouteGeneration: Boolean
+  )(in: Set[File]) = {
     in.foreach { swaggerFile =>
       log.debug(s"Swagger spec: $swaggerFile")
+      log.debug(s"Spec file: $specFile")
       log.debug(s"Is spec: ${specFile.exists(_.asFile == swaggerFile.asFile)}")
-      if(specFile.isEmpty || specFile.exists(_.asFile == swaggerFile.asFile)) {
+      if (specFile.isEmpty || specFile.exists(_.asFile == swaggerFile.asFile)) {
         log.info(s"[$generator] Generating source files from Swagger spec: $swaggerFile")
-        val generatorName = resolveConfigFromName(generator).getOrElse(sys.error(s"Failed to locate a generator by name $generator!"))
-        runCodegen(swaggerFile.toURI.toString, srcManagedDir, baseDir, generatorName.getClass.getName, basePkg, modelPkg, apiPkg, verbose)
+        val generatorConfig =
+          resolveConfigFromName(generator).getOrElse(sys.error(s"Failed to locate a generator by name $generator!"))
+        runCodegen(
+          swaggerFile = swaggerFile.toURI.toString,
+          srcManagedDir = srcManagedDir,
+          baseDir = baseDir,
+          targetDir = targetDir,
+          generator = generatorConfig,
+          basePkg = basePkg,
+          modelPkg = modelPkg,
+          apiPkg = apiPkg,
+          verbose = verbose,
+          skipRouteGeneration = skipRouteGeneration
+        )
       }
     }
 
     (srcManagedDir ** "*.scala").get.toSet
   }
 
-  private def runCodegen(swaggerFile: String,
-                         srcManagedDir: File,
-                         baseDir: File,
-                         generator: String,
-                         basePkg: Option[String],
-                         modelPkg: Option[String],
-                         apiPkg: Option[String],
-                         verbose: Boolean) = {
+  private def runCodegen(
+    swaggerFile: String,
+    srcManagedDir: File,
+    baseDir: File,
+    targetDir: File,
+    generator: CodegenConfig,
+    basePkg: Option[String],
+    modelPkg: Option[String],
+    apiPkg: Option[String],
+    verbose: Boolean,
+    skipRouteGeneration: Boolean
+  ): util.List[File] = {
     val configurator = new CodegenConfigurator()
     configurator.setVerbose(verbose)
 
@@ -113,10 +155,11 @@ object ModelGenerator {
       swaggerFile
     }
 
-    configurator.setLang(generator)
+    configurator.setLang(generator.getClass.getName)
     configurator.setInputSpecURL(specLocation)
     configurator.setOutputDir(baseDir.toString)
-    configurator.addAdditionalProperty("sourceManagedDir", srcManagedDir.toString)
+    configurator.addAdditionalProperty(BaseScalaCodegen.ARG_SRC_MANAGED_DIRECTORY, srcManagedDir.toString)
+    configurator.addAdditionalProperty(SimplePlayCodegen.ARG_SKIP_ROUTES_GENERATION, skipRouteGeneration.toString)
 
     // determine the scala package of the generated code by the
     // filename of the OpenAPI specification
@@ -128,8 +171,14 @@ object ModelGenerator {
     configurator.setModelPackage(modelPackage.getOrElse("model"))
     configurator.setApiPackage(apiPackage.getOrElse("api"))
 
-    val input: ClientOptInput = configurator.toClientOptInput
+    val templatesTargetPath = (targetDir / "templates" / generator.getName).toPath.toAbsolutePath
 
+    extractTemplatesFromResources(generator, templatesTargetPath)
+
+    // sets a custom template dir to one which we copied over to /target
+    configurator.setTemplateDir(templatesTargetPath.toString)
+
+    val input = configurator.toClientOptInput
 
     // configurator.toClientOptInput() attempts to read the file and parse an
     // OpenAPI specification. If it fails for any reason, that reason is
@@ -142,4 +191,31 @@ object ModelGenerator {
       .getOrElse(sys.error(s"Failed to load OpenAPI specification from $swaggerFile! Is it valid?"))
   }
 
+  /**
+    * Swagger has issues with reading template files which are stored in jar resources at the classpath.
+    * Therefore, we copy them to a directory in /target so that we can read the template from a regular directory.
+    */
+  private def extractTemplatesFromResources(generator: CodegenConfig, templatesTargetPath: Path): Unit = {
+    val templatesResource = s"templates/${generator.getName}"
+
+    val fs = FileSystems.newFileSystem(
+      classOf[SimplePlayCodegen].getClassLoader.getResource(templatesResource).toURI,
+      Collections.emptyMap[String, Any]
+    )
+
+    Files.createDirectories(templatesTargetPath)
+
+    Files.list(fs.getPath(templatesResource)).iterator().asScala.foreach { path =>
+      val target = Paths.get(templatesTargetPath.toString, path.getFileName.toString)
+      Using(Source.fromInputStream(Files.newInputStream(path)))(source =>
+        Files.write(
+          target,
+          source.getLines().toVector.asJava,
+          StandardOpenOption.WRITE,
+          StandardOpenOption.TRUNCATE_EXISTING,
+          StandardOpenOption.CREATE
+        )
+      )
+    }
+  }
 }

--- a/src/main/scala/io/grhodes/sbt/swagger/models/SbtSwaggerModelsPlugin.scala
+++ b/src/main/scala/io/grhodes/sbt/swagger/models/SbtSwaggerModelsPlugin.scala
@@ -1,57 +1,63 @@
 package io.grhodes.sbt.swagger.models
 
-import sbt._
-import sbt.Keys._
+import sbt.*
+import sbt.Keys.*
 import sbt.plugins.JvmPlugin
 
 object SbtSwaggerModelsPlugin extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
-  override def requires = JvmPlugin
+  override def requires: Plugins = JvmPlugin
 
   object autoImport {
-    val swaggerGenerateModels: TaskKey[Seq[File]] = taskKey[Seq[java.io.File]]("Generate models for swagger APIs")
-    val swaggerSourceDirectory: SettingKey[File] = settingKey[File]("Directory containing input swagger files")
-    val swaggerOutputPackage: SettingKey[Option[String]] = settingKey[Option[String]]("Package into which the source code should be generated")
-    val swaggerApiPackage: SettingKey[Option[String]] = settingKey[Option[String]]("Package into which the api source code should be generated")
-    val swaggerModelPackage: SettingKey[Option[String]] = settingKey[Option[String]]("Package into which the model source code should be generated")
-    val swaggerSpecFilename: SettingKey[Option[String]] = settingKey[Option[String]]("Optionally specify the service swagger spec file (all other swagger files are client specs)")
-    val swaggerEnumVendorExtensionName: SettingKey[Option[String]] = settingKey[Option[String]]("Optionally specify a vendor extension to be handled as an 'enum'")
-    val swaggerDisableTypesafeIds: SettingKey[Boolean] = settingKey[Boolean]("Request code generation to be done without typesafe Id encapsulation")
-    val swaggerTaggedAttributes: SettingKey[Seq[String]] = settingKey[Seq[String]]("Optionally tagged attributes")
-    val swaggerGenerator: SettingKey[String] = settingKey[String]("The swagger-codegen generator to use")
-    val swaggerGeneratorVerbose: SettingKey[Boolean] = settingKey[Boolean]("Turn on verbose for swagger-codegen generator")
+    val swaggerGenerateModels: TaskKey[Seq[File]] =
+      taskKey[Seq[java.io.File]]("Generate models for swagger APIs")
+    val swaggerSourceDirectory: SettingKey[File] =
+      settingKey[File]("Directory containing input swagger files")
+    val swaggerOutputPackage: SettingKey[Option[String]] =
+      settingKey[Option[String]]("Package into which the source code should be generated")
+    val swaggerApiPackage: SettingKey[Option[String]] =
+      settingKey[Option[String]]("Package into which the api source code should be generated")
+    val swaggerModelPackage: SettingKey[Option[String]] =
+      settingKey[Option[String]]("Package into which the model source code should be generated")
+    val swaggerSpecFilename: SettingKey[Option[String]] =
+      settingKey[Option[String]](
+        "Optionally specify the service swagger spec file (all other swagger files are client specs)"
+      )
+    val swaggerGenerator: SettingKey[String] =
+      settingKey[String]("The swagger-codegen generator to use")
+    val swaggerGeneratorVerbose: SettingKey[Boolean] =
+      settingKey[Boolean]("Turn on verbose for swagger-codegen generator")
+    val swaggerSkipRouteGeneration: SettingKey[Boolean] =
+      settingKey[Boolean]("Turn off the generation of Play routes in simple-play generator")
   }
 
-  import autoImport._
+  import autoImport.*
 
-  override lazy val projectSettings = Seq(
-    swaggerSourceDirectory := (resourceDirectory in Compile).value,
+  override lazy val projectSettings: Seq[Setting[?]] = Seq(
+    swaggerSourceDirectory := (Compile / resourceDirectory).value,
     swaggerOutputPackage := None,
     swaggerModelPackage := None,
     swaggerApiPackage := None,
     swaggerSpecFilename := Some("api.yaml"),
-    swaggerEnumVendorExtensionName := None,
-    swaggerDisableTypesafeIds := false,
-    swaggerTaggedAttributes := Seq(),
     swaggerGenerator := "simple-scala",
     swaggerGeneratorVerbose := false,
+    swaggerSkipRouteGeneration := false,
     swaggerGenerateModels := ModelGenerator(
       streams = streams.value,
-      srcManagedDir = (sourceManaged in Compile).value / "swagger",
-      srcDir = (swaggerSourceDirectory in swaggerGenerateModels).value,
-      baseDir = (baseDirectory in Compile).value,
-      specFile = (swaggerSpecFilename in swaggerGenerateModels).value,
-      basePkg = (swaggerOutputPackage in swaggerGenerateModels).value,
-      modelPkg = (swaggerModelPackage in swaggerGenerateModels).value,
-      apiPkg = (swaggerApiPackage in swaggerGenerateModels).value,
-      disableTypesafeIds = swaggerDisableTypesafeIds.value,
-      enumVendorExtensionName = swaggerEnumVendorExtensionName.value,
-      taggedAttributes = swaggerTaggedAttributes.value,
+      srcManagedDir = (Compile / sourceManaged).value / "swagger",
+      srcDir = (swaggerGenerateModels / swaggerSourceDirectory).value,
+      baseDir = (Compile / baseDirectory).value,
+      targetDir = (Compile / target).value,
+      specFile = (swaggerGenerateModels / swaggerSpecFilename).value,
+      basePkg = (swaggerGenerateModels / swaggerOutputPackage).value,
+      modelPkg = (swaggerGenerateModels / swaggerModelPackage).value,
+      apiPkg = (swaggerGenerateModels / swaggerApiPackage).value,
       generator = swaggerGenerator.value,
-      verbose = swaggerGeneratorVerbose.value
+      verbose = swaggerGeneratorVerbose.value,
+      skipRouteGeneration = swaggerSkipRouteGeneration.value
     ),
-    sourceGenerators in Compile += swaggerGenerateModels.taskValue
+    Compile / sourceGenerators += swaggerGenerateModels.taskValue
   )
 
 }

--- a/src/sbt-test/sbt-swagger-models/simple/build.sbt
+++ b/src/sbt-test/sbt-swagger-models/simple/build.sbt
@@ -1,6 +1,6 @@
 version := "0.1"
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.17"
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play" % "2.6.0-RC2",
-  "com.typesafe.play" %% "play-json" % "2.6.0-RC2"
+  "com.typesafe.play" %% "play" % "2.8.19",
+  "com.typesafe.play" %% "play-json" % "2.8.19"
 )

--- a/src/test/scala/io/grhodes/sbt/swagger/models/SbtswaggermodelsSpec.scala
+++ b/src/test/scala/io/grhodes/sbt/swagger/models/SbtswaggermodelsSpec.scala
@@ -1,11 +1,11 @@
 package io.grhodes.sbt.swagger.models
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SbtswaggermodelsSpec extends FlatSpec {
+class SbtswaggermodelsSpec extends AnyFlatSpec {
 
-  "an empty test" should "succeed" in { }
+  "an empty test" should "succeed" in {}
 
-  it should "succeed twice" in { }
+  it should "succeed twice" in {}
 
 }


### PR DESCRIPTION
Depends on: https://github.com/AYLIEN/simple-scala-generator/pull/2

1. Updates:
  a) Minor Scala update
  b) Latest SBT
  c) Latest Swagger
  d) Latest test deps
  e) JDK 11
2) Cleanup:
  a) Removed unused plugin options
  b) Removed unused code
3) Upgrade fix:
  a) Copying over custom codegen templates from classpath resources to /target, so that the latest Swaggert/SBT can read them.
4) New feature:
  a) Option to skip Play routes generation